### PR TITLE
Add keepAlive configuration to prevent connection timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,12 @@ new SonioxClient({
   // Maximum number of audio chunks to buffer in memory before the WebSocket connection is established.
   bufferQueueSize: 1000,
 
-  // If true, sends a keepalive message every 15 seconds to maintain the connection during periods of silence.
+  // If true, sends a keepalive message to maintain the connection during periods of silence.
   keepAlive: false,
+
+  // Interval in milliseconds for sending keepalive messages when keepAlive is enabled.
+  // Recommended: 5000-10000 (5-10 seconds). Default: 5000.
+  keepAliveInterval: 5000,
 
   // Callbacks on state changes, partial results and errors.
   onStarted: () => {
@@ -228,7 +232,7 @@ Maximum number of audio chunks to buffer in memory before the WebSocket connecti
 
 ##### `keepAlive`
 
-When set to `true`, automatically sends a keepalive message (`{"type": "keepalive"}`) every 15 seconds during active sessions. This prevents the WebSocket connection from timing out during periods of silence (e.g., when using client-side voice activity detection, during pauses in speech, or when temporarily pausing audio streaming).
+When set to `true`, automatically sends a keepalive message (`{"type": "keepalive"}`) at regular intervals during active sessions. This prevents the WebSocket connection from timing out during periods of silence (e.g., when using client-side voice activity detection, during pauses in speech, or when temporarily pausing audio streaming).
 
 **Default:** `false`
 
@@ -238,6 +242,12 @@ When set to `true`, automatically sends a keepalive message (`{"type": "keepaliv
 - You want to prevent connection timeouts during extended silences
 
 **Note**: You are charged for the full stream duration, not just the audio processed.
+
+##### `keepAliveInterval`
+
+Interval in milliseconds for sending keepalive messages when `keepAlive` is enabled. We recommend sending keepalive messages every 5-10 seconds.
+
+**Default:** `5000` (5 seconds)
 
 ##### `onStarted()`
 

--- a/src/soniox-client.ts
+++ b/src/soniox-client.ts
@@ -55,6 +55,12 @@ type SonioxClientOptions = {
    * Default: false.
    */
   keepAlive?: boolean;
+
+  /**
+   * Interval in milliseconds for sending keepalive messages when keepAlive is enabled.
+   * Default: 5000 (5 seconds).
+   */
+  keepAliveInterval?: number;
 } & Callbacks;
 
 type AudioOptions = {
@@ -400,11 +406,12 @@ export class SonioxClient {
 
     // Start keepalive interval if enabled
     if (this._options.keepAlive) {
+      const interval = this._options.keepAliveInterval ?? 5000;
       this._keepAliveInterval = setInterval(() => {
         if (this._state === 'Running' || this._state === 'FinishingProcessing') {
           this._websocket?.send(keepAliveMessage);
         }
-      }, 15000); // Send keepalive every 15 seconds
+      }, interval);
     }
   };
 


### PR DESCRIPTION
Introduces a new `keepAlive` option in SonioxClientOptions that automatically sends keepalive messages every 15 seconds during active sessions. This prevents WebSocket connections from timing out during periods of silence, such as when using client-side voice activity detection or during extended pauses in speech.

The feature defaults to false to maintain backward compatibility. When enabled, it ensures the connection stays alive and preserves session context (speaker labels, language tracking, prompt) during silent periods.

See also: https://soniox.com/docs/stt/rt/connection-keepalive